### PR TITLE
Add redirects from 2025-05-09-initial-log-analysis.md

### DIFF
--- a/config/match-redirects.vcl
+++ b/config/match-redirects.vcl
@@ -1,3 +1,71 @@
+if (req.http.host ~ "^sequel.") {
+  error 600 "https://sequel.jeremyevans.net";
+}
+
+if (req.http.host ~ "^rack.") {
+  error 600 "https://rack.github.io/rack/";
+}
+
+if (req.http.host ~ "^rake.") {
+  error 600 "https://ruby.github.io/rake/";
+}
+
+if (req.http.host ~ "^wxruby.") {
+  error 600 "https://github.com/mcorino/wxRuby3/wiki";
+}
+
+if (req.http.host ~ "^amazon.") {
+  error 600 "https://github.com/marcel/aws-s3";
+}
+
+if (req.http.host ~ "^god.") {
+  error 600 "http://godrb.com";
+}
+
+if (req.http.host ~ "^juggernaut.") {
+  error 600 "https://blog.alexmaccaw.com/killing-a-library/";
+}
+
+if (req.http.host ~ "^webgen.") {
+  error 600 "https://webgen.gettalong.org";
+}
+
+if (req.http.host ~ "^maruku.") {
+  error 600 "https://benhollis.net/blog/2013/10/20/maruku-is-obsolete/";
+}
+
+if (req.http.host ~ "^mechanize.") {
+  error 600 "https://www.rubydoc.info/gems/mechanize/";
+}
+
+if (req.http.host ~ "^rmagick.") {
+  error 600 "https://rmagick.github.io";
+}
+
+if (req.http.host ~ "^kramdown.") {
+  error 600 "https://kramdown.gettalong.org";
+}
+
+if (req.http.host ~ "^backgroundrb.") {
+  error 600 "https://github.com/gnufied/backgroundrb";
+}
+
+if (req.http.host ~ "^wtr.") {
+  error 600 "http://watir.com";
+}
+
+if (req.http.host ~ "^geokit.") {
+  error 600 "https://github.com/geokit/geokit";
+}
+
+if (req.http.host ~ "^libxml.") {
+  error 600 "https://xml4r.github.io/libxml-ruby/";
+}
+
+if (req.http.host ~ "^celerity.") {
+  error 600 "https://github.com/jarib/celerity";
+}
+
 if (req.http.host ~ "^gems.") {
   error 600 "https://rubygems.org";
 }

--- a/test/fastly-config-test.rb
+++ b/test/fastly-config-test.rb
@@ -18,6 +18,108 @@ class TestFastlyConfiguration < Minitest::Test
     assert_equal "http://www.#{DOMAIN}/", response['Location']
   end
 
+  def test_sequel
+    response = request "http://sequel.#{DOMAIN}"
+    assert_equal '301', response.code
+    assert_equal "https://sequel.jeremyevans.net", response['Location']
+  end
+
+  def test_rack
+    response = request "http://rack.#{DOMAIN}"
+    assert_equal '301', response.code
+    assert_equal "https://rack.github.io/rack/", response['Location']
+  end
+
+  def test_rake
+    response = request "http://rake.#{DOMAIN}"
+    assert_equal '301', response.code
+    assert_equal "https://ruby.github.io/rake/", response['Location']
+  end
+
+  def test_wxruby
+    response = request "http://wxruby.#{DOMAIN}"
+    assert_equal '301', response.code
+    assert_equal "https://github.com/mcorino/wxRuby3/wiki", response['Location']
+  end
+
+  def test_amazon
+    response = request "http://amazon.#{DOMAIN}"
+    assert_equal '301', response.code
+    assert_equal "https://github.com/marcel/aws-s3", response['Location']
+  end
+
+  def test_god
+    response = request "http://god.#{DOMAIN}"
+    assert_equal '301', response.code
+    assert_equal "http://godrb.com", response['Location']
+  end
+
+  def test_juggernaut
+    response = request "http://juggernaut.#{DOMAIN}"
+    assert_equal '301', response.code
+    assert_equal "https://blog.alexmaccaw.com/killing-a-library/", response['Location']
+  end
+
+  def test_webgen
+    response = request "http://webgen.#{DOMAIN}"
+    assert_equal '301', response.code
+    assert_equal "https://webgen.gettalong.org", response['Location']
+  end
+
+  def test_maruku
+    response = request "http://maruku.#{DOMAIN}"
+    assert_equal '301', response.code
+    assert_equal "https://benhollis.net/blog/2013/10/20/maruku-is-obsolete/", response['Location']
+  end
+
+  def test_mechanize
+    response = request "http://mechanize.#{DOMAIN}"
+    assert_equal '301', response.code
+    assert_equal "https://www.rubydoc.info/gems/mechanize/", response['Location']
+  end
+
+  def test_rmagick
+    response = request "http://rmagick.#{DOMAIN}"
+    assert_equal '301', response.code
+    assert_equal "https://rmagick.github.io", response['Location']
+  end
+
+  def test_kramdown
+    response = request "http://kramdown.#{DOMAIN}"
+    assert_equal '301', response.code
+    assert_equal "https://kramdown.gettalong.org", response['Location']
+  end
+
+  def test_backgroundrb
+    response = request "http://backgroundrb.#{DOMAIN}"
+    assert_equal '301', response.code
+    assert_equal "https://github.com/gnufied/backgroundrb", response['Location']
+  end
+
+  def test_wtr
+    response = request "http://wtr.#{DOMAIN}"
+    assert_equal '301', response.code
+    assert_equal "http://watir.com", response['Location']
+  end
+
+  def test_geokit
+    response = request "http://geokit.#{DOMAIN}"
+    assert_equal '301', response.code
+    assert_equal "https://github.com/geokit/geokit", response['Location']
+  end
+
+  def test_libxml
+    response = request "http://libxml.#{DOMAIN}"
+    assert_equal '301', response.code
+    assert_equal "https://xml4r.github.io/libxml-ruby/", response['Location']
+  end
+
+  def test_celerity
+    response = request "http://celerity.#{DOMAIN}"
+    assert_equal '301', response.code
+    assert_equal "https://github.com/jarib/celerity", response['Location']
+  end
+
   def test_gems
     response = request "http://gems.#{DOMAIN}"
     assert_equal '301', response.code


### PR DESCRIPTION
Many thanks to the [Internet Archive](https://archive.org)'s [Wayback Machine](https://web.archive.org)!

Notes:

- For projects that were retired/archived, I preferred redirecting to the announcement (if it was linked from the GitHub repository), otherwise falling back to the archived repository instead.
- URLs that begin with `http` (intsead of `https`) were only preserved if an `https` version was not available.